### PR TITLE
Keep services running while refreshing panel files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -208,9 +208,17 @@ CURRENT_DIR=$(pwd)
 
 echo "Setting up panel..."
 if [ "$CURRENT_DIR" != "$PANEL_DIR" ]; then
-    mkdir -p $PANEL_DIR
-    cp -r . $PANEL_DIR/
-    cd $PANEL_DIR
+    if [ -d "$PANEL_DIR" ]; then
+        echo "Existing panel directory detected at $PANEL_DIR"
+        echo "Removing existing contents in $PANEL_DIR before copying (services left running)..."
+        rm -rf "${PANEL_DIR}/"* "${PANEL_DIR}/".[!.]* "${PANEL_DIR}/"..?* 2>/dev/null || true
+    fi
+
+    mkdir -p "$PANEL_DIR"
+    echo "Copying project files to $PANEL_DIR..."
+    cp -a "$CURRENT_DIR"/. "$PANEL_DIR"/
+    rm -rf "$PANEL_DIR/.git"
+    cd "$PANEL_DIR"
 fi
 
 # Set proper ownership and permissions for panel files


### PR DESCRIPTION
## Summary
- avoid stopping nginx and php-fpm during installer file sync, simply clear and copy files
- keep messaging clear about removing existing contents while leaving services running

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fb14dcbc4832abac6e09bc447d983)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation script with safer, idempotent directory handling that clears existing content before reinstalling.
  * Enhanced file attribute preservation during the installation process.
  * Added clearer messaging and automatic directory setup after installation completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->