### PR TITLE
Handle existing MySQL panel user password during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -269,14 +269,15 @@ MYSQL_USER_EXISTS=$(mysql -u root -N -s -e "SELECT EXISTS(SELECT 1 FROM mysql.us
 
 if [ "$MYSQL_USER_EXISTS" = "1" ]; then
     echo "✓ MySQL user '${MYSQL_PANEL_USER}' already exists — resetting password"
+    USER_MANAGEMENT_SQL="ALTER USER '${MYSQL_PANEL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PANEL_PASS}';"
 else
     echo "✓ MySQL user '${MYSQL_PANEL_USER}' does not exist — creating user"
+    USER_MANAGEMENT_SQL="CREATE USER '${MYSQL_PANEL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PANEL_PASS}';"
 fi
 
 # Create or update the MySQL user with the generated password and ensure permissions are set
 mysql -u root <<MYSQL_EOF
-CREATE USER IF NOT EXISTS '${MYSQL_PANEL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PANEL_PASS}';
-ALTER USER '${MYSQL_PANEL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PANEL_PASS}';
+${USER_MANAGEMENT_SQL}
 GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_PANEL_USER}'@'localhost' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 MYSQL_EOF


### PR DESCRIPTION
## Summary
- detect when the `novapanel_db` MySQL user already exists and reset its password to the generated value
- ensure the same generated password is applied to user creation/updates and the configuration file for consistent re-installs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691fb755c61c832a8e35c496f095c424)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation robustness by detecting existing database users to avoid setup errors.
  * Unified create-or-reset password flow so installations now handle new user creation and existing password resets in one step.
  * Clarified installer messages to indicate whether a database user was created or had its password reset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->