### PR TITLE
Add observability, log viewer, security, and site templates

### DIFF
--- a/app/Facades/App.php
+++ b/app/Facades/App.php
@@ -178,8 +178,13 @@ class App
             WebServer::getInstance(),
             PhpRuntime::getInstance(),
             self::shell(),
-            new SiteTemplateService()
+            self::siteTemplateService()
         );
+    }
+
+    public static function siteTemplateService(): SiteTemplateService
+    {
+        return new SiteTemplateService();
     }
 
     /**

--- a/app/Facades/App.php
+++ b/app/Facades/App.php
@@ -18,6 +18,7 @@ use App\Services\CreateFtpUserService;
 use App\Services\AddCronJobService;
 use App\Services\SetupDnsZoneService;
 use App\Infrastructure\Shell\Shell;
+use App\Support\SiteTemplateService;
 
 /**
  * Application Facade
@@ -176,7 +177,8 @@ class App
             self::users(),
             WebServer::getInstance(),
             PhpRuntime::getInstance(),
-            self::shell()
+            self::shell(),
+            new SiteTemplateService()
         );
     }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,31 +2,41 @@
 
 namespace App\Http\Controllers;
 
+use App\Facades\App;
 use App\Http\Request;
 use App\Http\Response;
-use App\Facades\App;
+use App\Support\SystemStatusService;
 
 class DashboardController extends Controller
 {
     public function index(Request $request): Response
     {
-        $stats = $this->getStats();
-        
         return $this->view('pages/dashboard', [
             'title' => 'Dashboard',
-            'stats' => $stats
+            'stats' => $this->getStats(),
+            'systemStatus' => (new SystemStatusService())->snapshot(),
         ]);
     }
 
     public function stats(Request $request): Response
     {
         $stats = $this->getStats();
-        
-        // Return HTML fragment for HTMX using partial
+
         ob_start();
         include __DIR__ . '/../../../resources/views/partials/widgets/stats.php';
         $html = ob_get_clean();
-        
+
+        return new Response($html);
+    }
+
+    public function systemStatus(Request $request): Response
+    {
+        $systemStatus = (new SystemStatusService())->snapshot();
+
+        ob_start();
+        include __DIR__ . '/../../../resources/views/partials/widgets/system-status.php';
+        $html = ob_get_clean();
+
         return new Response($html);
     }
 
@@ -34,12 +44,12 @@ class DashboardController extends Controller
     {
         $users = App::users()->all();
         $sites = App::sites()->all();
-        
+
         return [
             'accounts' => count($users),
             'sites' => count($sites),
             'databases' => App::databases()->count(),
-            'ftp_users' => App::ftpUsers()->count()
+            'ftp_users' => App::ftpUsers()->count(),
         ];
     }
 }

--- a/app/Http/Controllers/LogsController.php
+++ b/app/Http/Controllers/LogsController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Request;
+use App\Http\Response;
+use App\Support\LogViewerService;
+
+class LogsController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $service = new LogViewerService();
+        $selected = $request->query('source', 'nginx_access');
+        $lines = (int) $request->query('lines', 200);
+
+        return $this->view('pages/logs/index', [
+            'title' => 'Log Viewer',
+            'sources' => $service->sources(),
+            'selected' => $selected,
+            'lines' => $lines,
+            'log' => $service->read($selected, $lines),
+        ]);
+    }
+}

--- a/app/Http/Controllers/LogsController.php
+++ b/app/Http/Controllers/LogsController.php
@@ -2,14 +2,22 @@
 
 namespace App\Http\Controllers;
 
+use App\Facades\App;
 use App\Http\Request;
 use App\Http\Response;
+use App\Http\Session;
 use App\Support\LogViewerService;
 
 class LogsController extends Controller
 {
     public function index(Request $request): Response
     {
+        Session::start();
+        $userId = (int) Session::get('user_id');
+        if ($userId <= 0 || !App::roles()->hasPermission($userId, 'system.logs')) {
+            return new Response('Forbidden', 403);
+        }
+
         $service = new LogViewerService();
         $selected = $request->query('source', 'nginx_access');
         $lines = (int) $request->query('lines', 200);

--- a/app/Http/Controllers/SecurityController.php
+++ b/app/Http/Controllers/SecurityController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Request;
+use App\Http\Response;
+use App\Support\SecurityManagerService;
+
+class SecurityController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $service = new SecurityManagerService();
+
+        return $this->view('pages/security/index', [
+            'title' => 'Security',
+            'overview' => $service->overview(),
+            'message' => $request->query('message'),
+            'error' => $request->query('error'),
+        ]);
+    }
+
+    public function runAction(Request $request): Response
+    {
+        $service = new SecurityManagerService();
+
+        try {
+            $result = $service->runAction((string) $request->post('action'));
+            return $this->redirect('/security?message=' . urlencode($result['output']));
+        } catch (\Throwable $exception) {
+            return $this->redirect('/security?error=' . urlencode($exception->getMessage()));
+        }
+    }
+}

--- a/app/Http/Controllers/SecurityController.php
+++ b/app/Http/Controllers/SecurityController.php
@@ -2,14 +2,21 @@
 
 namespace App\Http\Controllers;
 
+use App\Facades\App;
 use App\Http\Request;
 use App\Http\Response;
+use App\Http\Session;
+use App\Support\CSRF;
 use App\Support\SecurityManagerService;
 
 class SecurityController extends Controller
 {
     public function index(Request $request): Response
     {
+        if (!$this->canManageSecurity()) {
+            return new Response('Forbidden', 403);
+        }
+
         $service = new SecurityManagerService();
 
         return $this->view('pages/security/index', [
@@ -17,18 +24,38 @@ class SecurityController extends Controller
             'overview' => $service->overview(),
             'message' => $request->query('message'),
             'error' => $request->query('error'),
+            'csrfToken' => CSRF::getToken(),
         ]);
     }
 
     public function runAction(Request $request): Response
     {
-        $service = new SecurityManagerService();
+        if (!$this->canManageSecurity()) {
+            return new Response('Forbidden', 403);
+        }
 
         try {
+            if (!CSRF::verify((string) $request->post('_csrf_token'))) {
+                throw new \RuntimeException('Invalid CSRF token. Please refresh and try again.');
+            }
+
+            $service = new SecurityManagerService();
             $result = $service->runAction((string) $request->post('action'));
             return $this->redirect('/security?message=' . urlencode($result['output']));
         } catch (\Throwable $exception) {
             return $this->redirect('/security?error=' . urlencode($exception->getMessage()));
         }
+    }
+
+    private function canManageSecurity(): bool
+    {
+        Session::start();
+        $userId = (int) Session::get('user_id');
+
+        if ($userId <= 0) {
+            return false;
+        }
+
+        return App::roles()->hasPermission($userId, 'system.settings');
     }
 }

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -6,7 +6,6 @@ use App\Facades\App;
 use App\Http\Request;
 use App\Http\Response;
 use App\Support\AuditLogger;
-use App\Support\SiteTemplateService;
 
 class SiteController extends Controller
 {
@@ -28,7 +27,7 @@ class SiteController extends Controller
     public function create(Request $request): Response
     {
         $users = App::users()->all();
-        $templateService = new SiteTemplateService();
+        $templateService = App::siteTemplateService();
 
         return $this->view('pages/sites/create', [
             'title' => 'Create Site',
@@ -48,7 +47,7 @@ class SiteController extends Controller
             $template = (string) $request->post('template', 'basic_php');
 
             $service = App::createSiteService();
-            $site = $service->execute($userId, $domain, $phpVersion, $sslEnabled, $template);
+            $service->execute($userId, $domain, $phpVersion, $sslEnabled, $template);
 
             AuditLogger::logCreated('site', $domain, [
                 'user_id' => $userId,

--- a/app/Http/Controllers/SiteController.php
+++ b/app/Http/Controllers/SiteController.php
@@ -2,71 +2,71 @@
 
 namespace App\Http\Controllers;
 
+use App\Facades\App;
 use App\Http\Request;
 use App\Http\Response;
-use App\Facades\App;
 use App\Support\AuditLogger;
+use App\Support\SiteTemplateService;
 
 class SiteController extends Controller
 {
     public function index(Request $request): Response
     {
         $sites = App::sites()->all();
-        
-        // Load owner information for each site
+
         foreach ($sites as $site) {
             $user = App::users()->find($site->userId);
             $site->ownerUsername = $user ? $user->username : 'Unknown';
         }
-        
+
         return $this->view('pages/sites/index', [
             'title' => 'Sites',
-            'sites' => $sites
+            'sites' => $sites,
         ]);
     }
 
     public function create(Request $request): Response
     {
         $users = App::users()->all();
-        
+        $templateService = new SiteTemplateService();
+
         return $this->view('pages/sites/create', [
             'title' => 'Create Site',
-            'users' => $users
+            'users' => $users,
+            'templates' => $templateService->templates(),
+            'selectedTemplate' => $request->query('template', 'basic_php'),
         ]);
     }
 
     public function store(Request $request): Response
     {
         try {
-            $domain = $request->post('domain');
+            $domain = (string) $request->post('domain');
             $userId = (int) $request->post('user_id');
-            $phpVersion = $request->post('php_version', '8.2');
+            $phpVersion = (string) $request->post('php_version', '8.2');
             $sslEnabled = (bool) $request->post('ssl_enabled');
-            
-            // Use App facade to get service with all dependencies injected
+            $template = (string) $request->post('template', 'basic_php');
+
             $service = App::createSiteService();
-            
-            $site = $service->execute($userId, $domain, $phpVersion, $sslEnabled);
-            
-            // Log audit event
+            $site = $service->execute($userId, $domain, $phpVersion, $sslEnabled, $template);
+
             AuditLogger::logCreated('site', $domain, [
                 'user_id' => $userId,
                 'php_version' => $phpVersion,
-                'ssl_enabled' => $sslEnabled
+                'ssl_enabled' => $sslEnabled,
+                'template' => $template,
             ]);
-            
-            // Check if this is an HTMX request
+
             if ($request->isHtmx()) {
                 return new Response($this->successAlert('Site created successfully! Redirecting...'));
             }
-            
+
             return $this->redirect('/sites');
-            
         } catch (\Exception $e) {
-            // Check if this is an HTMX request
             if ($request->isHtmx()) {
                 return new Response($this->errorAlert($e->getMessage()), 400);
             }
+
             return $this->json(['error' => $e->getMessage()], 400);
         }
     }

--- a/app/Http/Controllers/TemplatesController.php
+++ b/app/Http/Controllers/TemplatesController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Request;
+use App\Http\Response;
+use App\Support\SiteTemplateService;
+
+class TemplatesController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $service = new SiteTemplateService();
+
+        return $this->view('pages/templates/index', [
+            'title' => 'Application Templates',
+            'templates' => $service->templates(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/TemplatesController.php
+++ b/app/Http/Controllers/TemplatesController.php
@@ -2,19 +2,24 @@
 
 namespace App\Http\Controllers;
 
+use App\Facades\App;
 use App\Http\Request;
 use App\Http\Response;
-use App\Support\SiteTemplateService;
+use App\Http\Session;
 
 class TemplatesController extends Controller
 {
     public function index(Request $request): Response
     {
-        $service = new SiteTemplateService();
+        Session::start();
+        $userId = (int) Session::get('user_id');
+        if ($userId <= 0 || !App::roles()->hasPermission($userId, 'sites.create')) {
+            return new Response('Forbidden', 403);
+        }
 
         return $this->view('pages/templates/index', [
             'title' => 'Application Templates',
-            'templates' => $service->templates(),
+            'templates' => App::siteTemplateService()->templates(),
         ]);
     }
 }

--- a/app/Http/Middleware/AuthMiddleware.php
+++ b/app/Http/Middleware/AuthMiddleware.php
@@ -19,13 +19,13 @@ class AuthMiddleware
             // Session validation failed (expired or hijacked)
             // Destroy the invalid session and redirect to login
             Session::destroy();
-            return $this->redirectToLogin();
+            return $this->redirectToLogin($request);
         }
         
         // Check if user is authenticated
         if (!$this->isAuthenticated()) {
             // Redirect to login page
-            return $this->redirectToLogin();
+            return $this->redirectToLogin($request);
         }
         
         return $next($request);
@@ -42,9 +42,13 @@ class AuthMiddleware
     /**
      * Redirect to login page
      */
-    private function redirectToLogin(): Response
+    private function redirectToLogin(Request $request): Response
     {
-        // Return a redirect response
+        if ($request->isHtmx()) {
+            header('HX-Redirect: /login');
+            exit;
+        }
+
         header('Location: /login');
         exit;
     }

--- a/app/Infrastructure/Shell/Shell.php
+++ b/app/Infrastructure/Shell/Shell.php
@@ -13,6 +13,8 @@ class Shell implements ShellInterface
     private array $allowedCommands = [
         'nginx',
         'systemctl',
+        'ufw',
+        'fail2ban-client',
         'mkdir',
         'chown',
         'chmod',
@@ -35,6 +37,7 @@ class Shell implements ShellInterface
     // Note: No Linux user management commands (useradd/usermod/userdel) are allowed
     private array $sudoCommands = [
         'systemctl',
+        'ufw',
         'mkdir',
         'chown',
         'chmod',

--- a/app/Services/CreateSiteService.php
+++ b/app/Services/CreateSiteService.php
@@ -2,13 +2,14 @@
 
 namespace App\Services;
 
-use App\Domain\Entities\Site;
-use App\Domain\Entities\PhpRuntime;
-use App\Repositories\SiteRepository;
-use App\Repositories\UserRepository;
-use App\Contracts\WebServerManagerInterface;
 use App\Contracts\PhpRuntimeManagerInterface;
 use App\Contracts\ShellInterface;
+use App\Contracts\WebServerManagerInterface;
+use App\Domain\Entities\PhpRuntime;
+use App\Domain\Entities\Site;
+use App\Repositories\SiteRepository;
+use App\Repositories\UserRepository;
+use App\Support\SiteTemplateService;
 
 class CreateSiteService
 {
@@ -17,32 +18,32 @@ class CreateSiteService
         private UserRepository $userRepository,
         private WebServerManagerInterface $webServerManager,
         private PhpRuntimeManagerInterface $phpRuntimeManager,
-        private ShellInterface $shell
+        private ShellInterface $shell,
+        private SiteTemplateService $siteTemplateService
     ) {}
 
     public function execute(
         int $userId,
         string $domain,
         string $phpVersion = '8.2',
-        bool $sslEnabled = false
+        bool $sslEnabled = false,
+        string $template = 'basic_php'
     ): Site {
-        // Validate domain
         if (!$this->isValidDomain($domain)) {
             throw new \InvalidArgumentException('Invalid domain format');
         }
 
-        // Check if site already exists
         if ($this->siteRepository->findByDomain($domain)) {
             throw new \RuntimeException("Site with domain '$domain' already exists");
         }
 
-        // Get user
         $user = $this->userRepository->find($userId);
         if (!$user) {
-            throw new \RuntimeException("User not found");
+            throw new \RuntimeException('User not found');
         }
 
-        // Validate PHP version is available
+        $this->siteTemplateService->find($template);
+
         $availableVersions = $this->phpRuntimeManager->listAvailable();
         $versionExists = false;
         foreach ($availableVersions as $runtime) {
@@ -55,12 +56,9 @@ class CreateSiteService
             throw new \InvalidArgumentException("PHP version {$phpVersion} is not installed on this system. Please install it first or choose an available version.");
         }
 
-        // Set document root under panel's directory structure
-        // All sites run under the panel user, organized by owner username
         $baseDir = "/opt/novapanel/sites/{$user->username}";
         $documentRoot = "{$baseDir}/{$domain}";
 
-        // Create site entity
         $site = new Site(
             userId: $userId,
             domain: $domain,
@@ -70,76 +68,63 @@ class CreateSiteService
             ownerUsername: $user->username
         );
 
-        // Save to database first
         $site = $this->siteRepository->create($site);
 
         try {
-            // Create base directory for user's sites if it doesn't exist
             if (!is_dir($baseDir)) {
                 $result = $this->shell->executeSudo('mkdir', ['-p', $baseDir]);
                 if ($result['exitCode'] !== 0) {
-                    throw new \RuntimeException("Failed to create base directory: " . $result['output']);
+                    throw new \RuntimeException('Failed to create base directory: ' . $result['output']);
                 }
-                // Set ownership to novapanel:www-data with group write permissions
                 $this->shell->executeSudo('chown', ['novapanel:www-data', $baseDir]);
                 $this->shell->executeSudo('chmod', ['775', $baseDir]);
             }
-            
-            // Create document root directory
+
             $result = $this->shell->executeSudo('mkdir', ['-p', $documentRoot]);
             if ($result['exitCode'] !== 0) {
-                throw new \RuntimeException("Failed to create document root: " . $result['output']);
+                throw new \RuntimeException('Failed to create document root: ' . $result['output']);
             }
-            // Set ownership to novapanel:www-data with group write permissions
             $this->shell->executeSudo('chown', ['novapanel:www-data', $documentRoot]);
             $this->shell->executeSudo('chmod', ['775', $documentRoot]);
 
-            // Create PHP-FPM pool
             $runtime = new PhpRuntime(
                 version: $phpVersion,
                 binary: "/usr/bin/php{$phpVersion}",
                 fpmSocket: "/var/run/php/php{$phpVersion}-fpm.sock"
             );
             $this->phpRuntimeManager->createPool($site, $runtime);
-
-            // Create Nginx vhost
             $this->webServerManager->createSite($site);
 
-            // Create default index.php
-            $indexContent = "<?php\necho '<h1>Welcome to {$domain}</h1>';\necho '<p>Site owner: {$user->username}</p>';\nphpinfo();\n";
-            file_put_contents("{$documentRoot}/index.php", $indexContent);
-
+            $this->siteTemplateService->apply($template, $documentRoot, [
+                'domain' => $domain,
+                'owner' => $user->username,
+            ]);
         } catch (\Exception $e) {
-            // Rollback: Clean up all created resources
-            error_log("Site creation failed for domain {$domain}: " . $e->getMessage());
-            
-            // Try to remove PHP-FPM pool if it was created
+            error_log('Site creation failed for domain ' . $domain . ': ' . $e->getMessage());
+
             try {
                 $this->phpRuntimeManager->deletePool($site);
             } catch (\Exception $poolError) {
-                error_log("Failed to rollback PHP-FPM pool for {$domain}: " . $poolError->getMessage());
+                error_log('Failed to rollback PHP-FPM pool for ' . $domain . ': ' . $poolError->getMessage());
             }
-            
-            // Try to remove Nginx vhost if it was created
+
             try {
                 $this->webServerManager->deleteSite($site);
             } catch (\Exception $vhostError) {
-                error_log("Failed to rollback Nginx vhost for {$domain}: " . $vhostError->getMessage());
+                error_log('Failed to rollback Nginx vhost for ' . $domain . ': ' . $vhostError->getMessage());
             }
-            
-            // Try to remove document root directory if it was created
+
             try {
                 if (is_dir($documentRoot)) {
                     $this->shell->executeSudo('rm', ['-rf', $documentRoot]);
                 }
             } catch (\Exception $dirError) {
-                error_log("Failed to rollback directory {$documentRoot}: " . $dirError->getMessage());
+                error_log('Failed to rollback directory ' . $documentRoot . ': ' . $dirError->getMessage());
             }
-            
-            // Delete from database
+
             $this->siteRepository->delete($site->id);
-            
-            throw new \RuntimeException("Failed to create site infrastructure: " . $e->getMessage());
+
+            throw new \RuntimeException('Failed to create site infrastructure: ' . $e->getMessage());
         }
 
         return $site;

--- a/app/Support/LogViewerService.php
+++ b/app/Support/LogViewerService.php
@@ -2,8 +2,6 @@
 
 namespace App\Support;
 
-use SplFileObject;
-
 class LogViewerService
 {
     private string $projectRoot;
@@ -65,7 +63,7 @@ class LogViewerService
     {
         $source = $this->findSource($sourceKey);
         $path = $source['path'];
-        $lines = max(25, min(500, $lines));
+        $lines = max(1, min(500, $lines));
 
         if ($path === null) {
             return [
@@ -91,14 +89,36 @@ class LogViewerService
             ];
         }
 
-        $content = implode("\n", $this->tailFile($path, $lines));
+        try {
+            clearstatcache(true, $path);
+
+            if (!file_exists($path) || !is_readable($path)) {
+                return [
+                    'source' => $source,
+                    'available' => false,
+                    'content' => sprintf('Log file not available: %s', $path),
+                ];
+            }
+
+            $content = implode("\n", $this->tailFile($path, $lines));
+
+            clearstatcache(true, $path);
+            $updatedAt = @filemtime($path);
+            $size = @filesize($path);
+        } catch (\Throwable) {
+            return [
+                'source' => $source,
+                'available' => false,
+                'content' => sprintf('Log file not available: %s', $path),
+            ];
+        }
 
         return [
             'source' => $source,
             'available' => true,
             'content' => $content !== '' ? $content : 'Log file is empty.',
-            'updated_at' => date('Y-m-d H:i:s', (int) filemtime($path)),
-            'size_human' => $this->formatBytes((int) filesize($path)),
+            'updated_at' => $updatedAt !== false ? date('Y-m-d H:i:s', (int) $updatedAt) : 'Unavailable',
+            'size_human' => $size !== false ? $this->formatBytes((int) $size) : 'Unavailable',
         ];
     }
 
@@ -154,24 +174,48 @@ class LogViewerService
      */
     private function tailFile(string $path, int $lines): array
     {
-        $file = new SplFileObject($path, 'r');
-        $file->seek(PHP_INT_MAX);
-        $lastLine = $file->key();
-        $start = max(0, $lastLine - $lines + 1);
-        $buffer = [];
-
-        $file->seek($start);
-
-        while (!$file->eof()) {
-            $buffer[] = rtrim((string) $file->current(), "\r\n");
-            $file->next();
+        $handle = @fopen($path, 'rb');
+        if ($handle === false) {
+            throw new \RuntimeException(sprintf('Unable to open log file: %s', $path));
         }
 
-        while ($buffer !== [] && end($buffer) === '') {
-            array_pop($buffer);
+        $buffer = '';
+        $position = @filesize($path);
+        $chunkSize = 4096;
+
+        if ($position === false) {
+            fclose($handle);
+            throw new \RuntimeException(sprintf('Unable to stat log file: %s', $path));
         }
 
-        return $buffer;
+        while ($position > 0 && substr_count($buffer, "\n") <= $lines) {
+            $readSize = min($chunkSize, $position);
+            $position -= $readSize;
+
+            if (fseek($handle, $position, SEEK_SET) !== 0) {
+                fclose($handle);
+                throw new \RuntimeException(sprintf('Unable to seek log file: %s', $path));
+            }
+
+            $chunk = fread($handle, $readSize);
+            if ($chunk === false) {
+                fclose($handle);
+                throw new \RuntimeException(sprintf('Unable to read log file: %s', $path));
+            }
+
+            $buffer = $chunk . $buffer;
+        }
+
+        fclose($handle);
+
+        $allLines = preg_split("/\r\n|\n|\r/", $buffer) ?: [];
+        $allLines = array_map(static fn (string $line): string => rtrim($line, "\r\n"), $allLines);
+
+        while ($allLines !== [] && end($allLines) === '') {
+            array_pop($allLines);
+        }
+
+        return array_slice($allLines, -$lines);
     }
 
     private function formatBytes(int $bytes): string

--- a/app/Support/LogViewerService.php
+++ b/app/Support/LogViewerService.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Support;
+
+use SplFileObject;
+
+class LogViewerService
+{
+    private string $projectRoot;
+
+    public function __construct(?string $projectRoot = null)
+    {
+        $this->projectRoot = $projectRoot ?? dirname(__DIR__, 2);
+    }
+
+    /**
+     * @return array<int, array<string, string|null>>
+     */
+    public function sources(): array
+    {
+        $phpFpmPath = $this->detectPhpFpmLogPath();
+        $appLogPath = $this->firstExistingPath([
+            $this->projectRoot . '/storage/logs/app.log',
+            $this->projectRoot . '/storage/logs/shell.log',
+        ]);
+
+        return [
+            [
+                'key' => 'nginx_access',
+                'label' => 'Nginx access',
+                'description' => 'Recent HTTP access activity handled by Nginx.',
+                'path' => '/var/log/nginx/access.log',
+            ],
+            [
+                'key' => 'nginx_error',
+                'label' => 'Nginx error',
+                'description' => 'Nginx upstream, routing, and configuration errors.',
+                'path' => '/var/log/nginx/error.log',
+            ],
+            [
+                'key' => 'php_fpm',
+                'label' => 'PHP-FPM',
+                'description' => 'PHP-FPM worker, pool, and runtime events.',
+                'path' => $phpFpmPath,
+            ],
+            [
+                'key' => 'panel_audit',
+                'label' => 'Panel audit',
+                'description' => 'Audit history for panel actions and auth events.',
+                'path' => $this->projectRoot . '/storage/logs/audit.log',
+            ],
+            [
+                'key' => 'panel_app',
+                'label' => 'Panel application',
+                'description' => 'Operational log for shell and panel internals.',
+                'path' => $appLogPath,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function read(string $sourceKey, int $lines = 200): array
+    {
+        $source = $this->findSource($sourceKey);
+        $path = $source['path'];
+        $lines = max(25, min(500, $lines));
+
+        if ($path === null) {
+            return [
+                'source' => $source,
+                'available' => false,
+                'content' => sprintf('%s is not available on this host yet.', $source['label']),
+            ];
+        }
+
+        if (!file_exists($path)) {
+            return [
+                'source' => $source,
+                'available' => false,
+                'content' => sprintf('Log file not found: %s', $path),
+            ];
+        }
+
+        if (!is_readable($path)) {
+            return [
+                'source' => $source,
+                'available' => false,
+                'content' => sprintf('Log file is not readable by the panel process: %s', $path),
+            ];
+        }
+
+        $content = implode("\n", $this->tailFile($path, $lines));
+
+        return [
+            'source' => $source,
+            'available' => true,
+            'content' => $content !== '' ? $content : 'Log file is empty.',
+            'updated_at' => date('Y-m-d H:i:s', (int) filemtime($path)),
+            'size_human' => $this->formatBytes((int) filesize($path)),
+        ];
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    public function defaultSource(): array
+    {
+        return $this->sources()[0];
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function findSource(string $sourceKey): array
+    {
+        foreach ($this->sources() as $source) {
+            if ($source['key'] === $sourceKey) {
+                return $source;
+            }
+        }
+
+        return $this->defaultSource();
+    }
+
+    private function detectPhpFpmLogPath(): ?string
+    {
+        $paths = array_merge(
+            glob('/var/log/php*-fpm.log') ?: [],
+            glob('/var/log/php/*fpm*.log') ?: [],
+            glob('/var/log/php*/fpm*.log') ?: []
+        );
+
+        return $this->firstExistingPath($paths);
+    }
+
+    /**
+     * @param array<int, string> $paths
+     */
+    private function firstExistingPath(array $paths): ?string
+    {
+        foreach ($paths as $path) {
+            if ($path !== '' && file_exists($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function tailFile(string $path, int $lines): array
+    {
+        $file = new SplFileObject($path, 'r');
+        $file->seek(PHP_INT_MAX);
+        $lastLine = $file->key();
+        $start = max(0, $lastLine - $lines + 1);
+        $buffer = [];
+
+        $file->seek($start);
+
+        while (!$file->eof()) {
+            $buffer[] = rtrim((string) $file->current(), "\r\n");
+            $file->next();
+        }
+
+        while ($buffer !== [] && end($buffer) === '') {
+            array_pop($buffer);
+        }
+
+        return $buffer;
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes <= 0) {
+            return '0 B';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $power = min((int) floor(log($bytes, 1024)), count($units) - 1);
+        $value = $bytes / (1024 ** $power);
+
+        return sprintf('%.1f %s', $value, $units[$power]);
+    }
+}

--- a/app/Support/SecurityManagerService.php
+++ b/app/Support/SecurityManagerService.php
@@ -2,8 +2,13 @@
 
 namespace App\Support;
 
+use App\Facades\App;
+use App\Infrastructure\Shell\Shell;
+
 class SecurityManagerService
 {
+    private Shell $shell;
+
     /**
      * @var array<string, array<string, string>>
      */
@@ -11,14 +16,23 @@ class SecurityManagerService
         'ufw_reload' => [
             'label' => 'Reload UFW',
             'component' => 'ufw',
-            'command' => 'sudo -n ufw reload',
+            'command' => 'ufw',
+            'args' => 'reload',
+            'sudo' => 'true',
         ],
         'fail2ban_restart' => [
             'label' => 'Restart fail2ban',
             'component' => 'fail2ban',
-            'command' => 'sudo -n systemctl restart fail2ban',
+            'command' => 'systemctl',
+            'args' => 'restart fail2ban',
+            'sudo' => 'true',
         ],
     ];
+
+    public function __construct(?Shell $shell = null)
+    {
+        $this->shell = $shell ?? App::shell();
+    }
 
     /**
      * @return array<string, mixed>
@@ -64,7 +78,11 @@ class SecurityManagerService
         }
 
         $definition = $this->actions[$action];
-        $result = $this->execCommand($definition['command']);
+        $result = $this->execCommand(
+            $definition['command'],
+            $definition['args'] !== '' ? explode(' ', $definition['args']) : [],
+            ($definition['sudo'] ?? 'false') === 'true'
+        );
 
         if ($result['exit_code'] !== 0) {
             throw new \RuntimeException(trim($result['output']) ?: 'Security action failed.');
@@ -94,8 +112,7 @@ class SecurityManagerService
             return $this->statusPayload('not installed', 'secondary', 'UFW is not installed on this host.');
         }
 
-        $command = $this->canRunPrivilegedActions() ? 'sudo -n ufw status' : 'ufw status';
-        $result = $this->execCommand($command);
+        $result = $this->execCommand('ufw', ['status'], $this->canRunPrivilegedActions());
         $output = trim($result['output']);
 
         if (stripos($output, 'Status: active') !== false) {
@@ -123,7 +140,8 @@ class SecurityManagerService
         }
 
         if ($this->commandExists('systemctl')) {
-            $state = trim((string) shell_exec('systemctl show fail2ban --property=ActiveState --value 2>/dev/null'));
+            $result = $this->execCommand('systemctl', ['show', 'fail2ban', '--property=ActiveState', '--value']);
+            $state = ($result['exit_code'] === 0) ? trim($result['output']) : '';
 
             if ($state !== '') {
                 return $this->statusPayload(
@@ -134,7 +152,7 @@ class SecurityManagerService
             }
         }
 
-        $result = $this->execCommand('fail2ban-client ping');
+        $result = $this->execCommand('fail2ban-client', ['ping']);
 
         if ($result['exit_code'] === 0 && stripos($result['output'], 'Server replied') !== false) {
             return $this->statusPayload('active', 'success', trim($result['output']));
@@ -161,13 +179,13 @@ class SecurityManagerService
             return true;
         }
 
-        $result = $this->execCommand('sudo -n true');
+        $result = $this->execCommand('systemctl', ['--version'], true);
         return $result['exit_code'] === 0;
     }
 
     private function commandExists(string $command): bool
     {
-        $result = $this->execCommand(sprintf('command -v %s', escapeshellarg($command)));
+        $result = $this->execCommand('bash', ['-lc', sprintf('command -v %s', escapeshellarg($command))]);
         return trim($result['output']) !== '';
     }
 
@@ -177,22 +195,25 @@ class SecurityManagerService
             return false;
         }
 
-        $state = trim((string) shell_exec(sprintf('systemctl show %s --property=LoadState --value 2>/dev/null', escapeshellarg($unit))));
+        $result = $this->execCommand('systemctl', ['show', $unit, '--property=LoadState', '--value']);
+        $state = ($result['exit_code'] === 0) ? trim($result['output']) : '';
         return $state !== '' && $state !== 'not-found';
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function execCommand(string $command): array
+    private function execCommand(string $command, array $args = [], bool $sudo = false): array
     {
-        $output = [];
-        $exitCode = 0;
-        exec($command . ' 2>&1', $output, $exitCode);
+        if ($sudo) {
+            $result = $this->shell->executeSudo($command, $args);
+        } else {
+            $result = $this->shell->execute($command, $args);
+        }
 
         return [
-            'output' => implode("\n", $output),
-            'exit_code' => $exitCode,
+            'output' => (string) ($result['output'] ?? ''),
+            'exit_code' => (int) ($result['exitCode'] ?? 1),
         ];
     }
 }

--- a/app/Support/SecurityManagerService.php
+++ b/app/Support/SecurityManagerService.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace App\Support;
+
+class SecurityManagerService
+{
+    /**
+     * @var array<string, array<string, string>>
+     */
+    private array $actions = [
+        'ufw_reload' => [
+            'label' => 'Reload UFW',
+            'component' => 'ufw',
+            'command' => 'sudo -n ufw reload',
+        ],
+        'fail2ban_restart' => [
+            'label' => 'Restart fail2ban',
+            'component' => 'fail2ban',
+            'command' => 'sudo -n systemctl restart fail2ban',
+        ],
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function overview(): array
+    {
+        $canManage = $this->canRunPrivilegedActions();
+        $ufwInstalled = $this->commandExists('ufw');
+        $fail2banInstalled = $this->commandExists('fail2ban-client') || $this->systemdUnitExists('fail2ban');
+
+        return [
+            'can_manage' => $canManage,
+            'components' => [
+                [
+                    'key' => 'ufw',
+                    'label' => 'UFW firewall',
+                    'installed' => $ufwInstalled,
+                    'status' => $this->ufwStatus($ufwInstalled),
+                    'actions' => $ufwInstalled ? [$this->withKey('ufw_reload')] : [],
+                ],
+                [
+                    'key' => 'fail2ban',
+                    'label' => 'fail2ban',
+                    'installed' => $fail2banInstalled,
+                    'status' => $this->fail2banStatus($fail2banInstalled),
+                    'actions' => $fail2banInstalled ? [$this->withKey('fail2ban_restart')] : [],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function runAction(string $action): array
+    {
+        if (!isset($this->actions[$action])) {
+            throw new \InvalidArgumentException('Unsupported security action requested.');
+        }
+
+        if (!$this->canRunPrivilegedActions()) {
+            throw new \RuntimeException('Controlled actions require passwordless sudo for the panel user.');
+        }
+
+        $definition = $this->actions[$action];
+        $result = $this->execCommand($definition['command']);
+
+        if ($result['exit_code'] !== 0) {
+            throw new \RuntimeException(trim($result['output']) ?: 'Security action failed.');
+        }
+
+        return [
+            'label' => $definition['label'],
+            'output' => trim($result['output']) ?: $definition['label'] . ' completed successfully.',
+        ];
+    }
+
+
+    /**
+     * @return array<string, string>
+     */
+    private function withKey(string $action): array
+    {
+        return ['key' => $action] + $this->actions[$action];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function ufwStatus(bool $installed): array
+    {
+        if (!$installed) {
+            return $this->statusPayload('not installed', 'secondary', 'UFW is not installed on this host.');
+        }
+
+        $command = $this->canRunPrivilegedActions() ? 'sudo -n ufw status' : 'ufw status';
+        $result = $this->execCommand($command);
+        $output = trim($result['output']);
+
+        if (stripos($output, 'Status: active') !== false) {
+            return $this->statusPayload('active', 'success', $output);
+        }
+
+        if (stripos($output, 'Status: inactive') !== false) {
+            return $this->statusPayload('inactive', 'warning', $output);
+        }
+
+        if ($output === '') {
+            return $this->statusPayload('unknown', 'secondary', 'Unable to determine UFW status.');
+        }
+
+        return $this->statusPayload('unknown', 'secondary', $output);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function fail2banStatus(bool $installed): array
+    {
+        if (!$installed) {
+            return $this->statusPayload('not installed', 'secondary', 'fail2ban is not installed on this host.');
+        }
+
+        if ($this->commandExists('systemctl')) {
+            $state = trim((string) shell_exec('systemctl show fail2ban --property=ActiveState --value 2>/dev/null'));
+
+            if ($state !== '') {
+                return $this->statusPayload(
+                    $state,
+                    $state === 'active' ? 'success' : 'warning',
+                    sprintf('fail2ban service state: %s', $state)
+                );
+            }
+        }
+
+        $result = $this->execCommand('fail2ban-client ping');
+
+        if ($result['exit_code'] === 0 && stripos($result['output'], 'Server replied') !== false) {
+            return $this->statusPayload('active', 'success', trim($result['output']));
+        }
+
+        return $this->statusPayload('inactive', 'warning', trim($result['output']) ?: 'fail2ban did not respond to ping.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function statusPayload(string $state, string $badge, string $details): array
+    {
+        return [
+            'state' => $state,
+            'badge' => $badge,
+            'details' => $details,
+        ];
+    }
+
+    private function canRunPrivilegedActions(): bool
+    {
+        if (function_exists('posix_geteuid') && posix_geteuid() === 0) {
+            return true;
+        }
+
+        $result = $this->execCommand('sudo -n true');
+        return $result['exit_code'] === 0;
+    }
+
+    private function commandExists(string $command): bool
+    {
+        $result = $this->execCommand(sprintf('command -v %s', escapeshellarg($command)));
+        return trim($result['output']) !== '';
+    }
+
+    private function systemdUnitExists(string $unit): bool
+    {
+        if (!$this->commandExists('systemctl')) {
+            return false;
+        }
+
+        $state = trim((string) shell_exec(sprintf('systemctl show %s --property=LoadState --value 2>/dev/null', escapeshellarg($unit))));
+        return $state !== '' && $state !== 'not-found';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function execCommand(string $command): array
+    {
+        $output = [];
+        $exitCode = 0;
+        exec($command . ' 2>&1', $output, $exitCode);
+
+        return [
+            'output' => implode("\n", $output),
+            'exit_code' => $exitCode,
+        ];
+    }
+}

--- a/app/Support/SiteTemplateService.php
+++ b/app/Support/SiteTemplateService.php
@@ -54,8 +54,8 @@ class SiteTemplateService
 
         foreach ($this->directoriesFor($key) as $directory) {
             $path = rtrim($documentRoot, '/') . '/' . ltrim($directory, '/');
-            if (!is_dir($path)) {
-                mkdir($path, 0775, true);
+            if (!is_dir($path) && !mkdir($path, 0775, true) && !is_dir($path)) {
+                throw new \RuntimeException(sprintf('Failed to create template directory: %s', $path));
             }
         }
 
@@ -63,11 +63,13 @@ class SiteTemplateService
             $path = rtrim($documentRoot, '/') . '/' . ltrim($relativePath, '/');
             $parent = dirname($path);
 
-            if (!is_dir($parent)) {
-                mkdir($parent, 0775, true);
+            if (!is_dir($parent) && !mkdir($parent, 0775, true) && !is_dir($parent)) {
+                throw new \RuntimeException(sprintf('Failed to create template directory: %s', $parent));
             }
 
-            file_put_contents($path, $content);
+            if (file_put_contents($path, $content, LOCK_EX) === false) {
+                throw new \RuntimeException(sprintf('Failed to write template file: %s', $path));
+            }
         }
     }
 
@@ -90,8 +92,11 @@ class SiteTemplateService
      */
     private function filesFor(string $key, array $context): array
     {
-        $domain = $context['domain'] ?? 'example.com';
-        $owner = $context['owner'] ?? 'novapanel';
+        $domain = $this->normalizeDomain($context['domain'] ?? 'example.com');
+        $owner = $this->normalizeOwner($context['owner'] ?? 'novapanel');
+        $domainHtml = htmlspecialchars($domain, ENT_QUOTES, 'UTF-8');
+        $ownerHtml = htmlspecialchars($owner, ENT_QUOTES, 'UTF-8');
+        $domainPhp = var_export($domain, true);
 
         return match ($key) {
             'basic_php' => [
@@ -99,6 +104,7 @@ class SiteTemplateService
 <?php
 
 \$appName = 'NovaPanel Starter';
+\$domain = {$domainPhp};
 ?>
 <!doctype html>
 <html lang="en">
@@ -114,15 +120,15 @@ class SiteTemplateService
 </head>
 <body>
     <div class="card">
-        <p>Provisioned by NovaPanel for {$owner}</p>
+        <p>Provisioned by NovaPanel for {$ownerHtml}</p>
         <h1><?= htmlspecialchars(\$appName) ?></h1>
-        <p>Your site for <strong>{$domain}</strong> is live and ready for application code.</p>
+        <p>Your site for <strong><?= htmlspecialchars(\$domain, ENT_QUOTES, 'UTF-8') ?></strong> is live and ready for application code.</p>
         <p>Use <code>tmp/</code> for uploads and local runtime files that should stay writable.</p>
     </div>
 </body>
 </html>
 PHP,
-                'README.md' => "# Basic PHP template\n\nThis site was scaffolded for {$domain}. Replace `index.php` with your app entrypoint and keep writable data inside `tmp/`.\n",
+                'README.md' => "# Basic PHP template\n\nThis site was scaffolded for {$domainHtml}. Replace `index.php` with your app entrypoint and keep writable data inside `tmp/`.\n",
             ],
             'wordpress' => [
                 'index.php' => <<<PHP
@@ -146,7 +152,7 @@ if (file_exists(__DIR__ . '/wp-blog-header.php')) {
 </head>
 <body>
     <div class="shell">
-        <p>NovaPanel created a WordPress-ready deployment for <strong>{$domain}</strong>.</p>
+        <p>NovaPanel created a WordPress-ready deployment for <strong>{$domainHtml}</strong>.</p>
         <h1>Finish WordPress setup</h1>
         <ol>
             <li>Create a MySQL database and user in NovaPanel.</li>
@@ -166,12 +172,12 @@ define('DB_USER', 'replace_me');
 define('DB_PASSWORD', 'replace_me');
 define('DB_HOST', '127.0.0.1');
 
-define('WP_HOME', 'https://{$domain}');
-define('WP_SITEURL', 'https://{$domain}');
+define('WP_HOME', 'https://{$domainHtml}');
+define('WP_SITEURL', 'https://{$domainHtml}');
 
 $table_prefix = 'wp_';
 PHP,
-                'README.md' => "# WordPress-ready template\n\nProvisioned for {$domain} and owned by {$owner}. Upload the official WordPress package into this document root, create `wp-config.php`, and finish the installer from `/wp-admin/install.php`.\n",
+                'README.md' => "# WordPress-ready template\n\nProvisioned for {$domainHtml} and owned by {$ownerHtml}. Upload the official WordPress package into this document root, create `wp-config.php`, and finish the installer from `/wp-admin/install.php`.\n",
             ],
             'static_site' => [
                 'index.html' => <<<HTML
@@ -180,13 +186,13 @@ PHP,
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{$domain}</title>
+    <title>{$domainHtml}</title>
     <link rel="stylesheet" href="/assets/css/site.css">
 </head>
 <body>
     <main>
         <span class="eyebrow">NovaPanel static template</span>
-        <h1>{$domain}</h1>
+        <h1>{$domainHtml}</h1>
         <p>Launch a documentation site, product landing page, or marketing microsite quickly.</p>
     </main>
 </body>
@@ -218,9 +224,26 @@ main {
     color: #bfdbfe;
 }
 CSS,
-                'README.md' => "# Static site template\n\nThis site was scaffolded for {$domain}. Replace `index.html` and `assets/css/site.css` with your static assets.\n",
+                'README.md' => "# Static site template\n\nThis site was scaffolded for {$domainHtml}. Replace `index.html` and `assets/css/site.css` with your static assets.\n",
             ],
             default => [],
         };
+    }
+
+    private function normalizeDomain(string $domain): string
+    {
+        $normalized = strtolower(trim($domain));
+        if ($normalized === '') {
+            return 'example.com';
+        }
+
+        $isValid = filter_var($normalized, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) !== false;
+        return $isValid ? $normalized : 'example.com';
+    }
+
+    private function normalizeOwner(string $owner): string
+    {
+        $normalized = preg_replace('/[^a-zA-Z0-9._-]/', '', trim($owner)) ?? '';
+        return $normalized !== '' ? $normalized : 'novapanel';
     }
 }

--- a/app/Support/SiteTemplateService.php
+++ b/app/Support/SiteTemplateService.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Support;
+
+class SiteTemplateService
+{
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function templates(): array
+    {
+        return [
+            [
+                'key' => 'basic_php',
+                'name' => 'Basic PHP app',
+                'summary' => 'A clean starter with a PHP landing page and writable tmp directory.',
+                'stack' => 'PHP-FPM + Nginx',
+            ],
+            [
+                'key' => 'wordpress',
+                'name' => 'WordPress-ready deployment',
+                'summary' => 'Bootstraps a WordPress-ready document root with setup notes and content folders.',
+                'stack' => 'PHP + MySQL',
+            ],
+            [
+                'key' => 'static_site',
+                'name' => 'Static site',
+                'summary' => 'Minimal HTML/CSS starter for landing pages, docs, and brochure sites.',
+                'stack' => 'Nginx only',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function find(string $key): array
+    {
+        foreach ($this->templates() as $template) {
+            if ($template['key'] === $key) {
+                return $template;
+            }
+        }
+
+        throw new \InvalidArgumentException('Unknown site template selected.');
+    }
+
+    /**
+     * @param array<string, string> $context
+     */
+    public function apply(string $key, string $documentRoot, array $context): void
+    {
+        $this->find($key);
+
+        foreach ($this->directoriesFor($key) as $directory) {
+            $path = rtrim($documentRoot, '/') . '/' . ltrim($directory, '/');
+            if (!is_dir($path)) {
+                mkdir($path, 0775, true);
+            }
+        }
+
+        foreach ($this->filesFor($key, $context) as $relativePath => $content) {
+            $path = rtrim($documentRoot, '/') . '/' . ltrim($relativePath, '/');
+            $parent = dirname($path);
+
+            if (!is_dir($parent)) {
+                mkdir($parent, 0775, true);
+            }
+
+            file_put_contents($path, $content);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function directoriesFor(string $key): array
+    {
+        return match ($key) {
+            'basic_php' => ['tmp', 'public'],
+            'wordpress' => ['wp-content', 'wp-content/uploads', 'wp-content/plugins', 'wp-content/themes'],
+            'static_site' => ['assets', 'assets/css'],
+            default => [],
+        };
+    }
+
+    /**
+     * @param array<string, string> $context
+     * @return array<string, string>
+     */
+    private function filesFor(string $key, array $context): array
+    {
+        $domain = $context['domain'] ?? 'example.com';
+        $owner = $context['owner'] ?? 'novapanel';
+
+        return match ($key) {
+            'basic_php' => [
+                'index.php' => <<<PHP
+<?php
+
+\$appName = 'NovaPanel Starter';
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title><?= htmlspecialchars(\$appName) ?></title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 3rem; background: #0f172a; color: #e2e8f0; }
+        .card { max-width: 720px; background: #111827; border-radius: 16px; padding: 2rem; }
+        code { color: #93c5fd; }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <p>Provisioned by NovaPanel for {$owner}</p>
+        <h1><?= htmlspecialchars(\$appName) ?></h1>
+        <p>Your site for <strong>{$domain}</strong> is live and ready for application code.</p>
+        <p>Use <code>tmp/</code> for uploads and local runtime files that should stay writable.</p>
+    </div>
+</body>
+</html>
+PHP,
+                'README.md' => "# Basic PHP template\n\nThis site was scaffolded for {$domain}. Replace `index.php` with your app entrypoint and keep writable data inside `tmp/`.\n",
+            ],
+            'wordpress' => [
+                'index.php' => <<<PHP
+<?php
+if (file_exists(__DIR__ . '/wp-blog-header.php')) {
+    require __DIR__ . '/wp-blog-header.php';
+    return;
+}
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>WordPress ready</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 3rem; background: #f8fafc; color: #0f172a; }
+        .shell { max-width: 760px; background: #fff; border: 1px solid #cbd5e1; border-radius: 16px; padding: 2rem; }
+        code { background: #e2e8f0; padding: 0.1rem 0.35rem; border-radius: 6px; }
+    </style>
+</head>
+<body>
+    <div class="shell">
+        <p>NovaPanel created a WordPress-ready deployment for <strong>{$domain}</strong>.</p>
+        <h1>Finish WordPress setup</h1>
+        <ol>
+            <li>Create a MySQL database and user in NovaPanel.</li>
+            <li>Upload or unpack WordPress core files into this document root.</li>
+            <li>Copy <code>wp-config-sample.php</code> to <code>wp-config.php</code> and add your database credentials.</li>
+            <li>Visit <code>/wp-admin/install.php</code> to complete the installer.</li>
+        </ol>
+    </div>
+</body>
+</html>
+PHP,
+                'wp-config-sample.php' => <<<PHP
+<?php
+
+define('DB_NAME', 'replace_me');
+define('DB_USER', 'replace_me');
+define('DB_PASSWORD', 'replace_me');
+define('DB_HOST', '127.0.0.1');
+
+define('WP_HOME', 'https://{$domain}');
+define('WP_SITEURL', 'https://{$domain}');
+
+$table_prefix = 'wp_';
+PHP,
+                'README.md' => "# WordPress-ready template\n\nProvisioned for {$domain} and owned by {$owner}. Upload the official WordPress package into this document root, create `wp-config.php`, and finish the installer from `/wp-admin/install.php`.\n",
+            ],
+            'static_site' => [
+                'index.html' => <<<HTML
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{$domain}</title>
+    <link rel="stylesheet" href="/assets/css/site.css">
+</head>
+<body>
+    <main>
+        <span class="eyebrow">NovaPanel static template</span>
+        <h1>{$domain}</h1>
+        <p>Launch a documentation site, product landing page, or marketing microsite quickly.</p>
+    </main>
+</body>
+</html>
+HTML,
+                'assets/css/site.css' => <<<CSS
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(135deg, #0f172a, #1d4ed8);
+    color: #fff;
+}
+
+main {
+    text-align: center;
+    max-width: 720px;
+    padding: 2rem;
+}
+
+.eyebrow {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #bfdbfe;
+}
+CSS,
+                'README.md' => "# Static site template\n\nThis site was scaffolded for {$domain}. Replace `index.html` and `assets/css/site.css` with your static assets.\n",
+            ],
+            default => [],
+        };
+    }
+}

--- a/app/Support/SystemStatusService.php
+++ b/app/Support/SystemStatusService.php
@@ -2,8 +2,18 @@
 
 namespace App\Support;
 
+use App\Facades\App;
+use App\Infrastructure\Shell\Shell;
+
 class SystemStatusService
 {
+    private Shell $shell;
+
+    public function __construct(?Shell $shell = null)
+    {
+        $this->shell = $shell ?? App::shell();
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -55,6 +65,8 @@ class SystemStatusService
             ];
         }
 
+        $firstInstalled = null;
+
         foreach ($units as $unit) {
             $loadState = trim($this->runCommand(sprintf('systemctl show %s --property=LoadState --value 2>/dev/null', escapeshellarg($unit))));
 
@@ -67,7 +79,7 @@ class SystemStatusService
 
             $healthy = $activeState === 'active';
 
-            return [
+            $candidate = [
                 'key' => $key,
                 'label' => $label,
                 'unit' => $unit,
@@ -79,6 +91,18 @@ class SystemStatusService
                     ? sprintf('Unit %s is %s (%s).', $unit, $activeState ?: 'unknown', $subState)
                     : sprintf('Unit %s is %s.', $unit, $activeState ?: 'unknown'),
             ];
+
+            if ($healthy) {
+                return $candidate;
+            }
+
+            if ($firstInstalled === null) {
+                $firstInstalled = $candidate;
+            }
+        }
+
+        if ($firstInstalled !== null) {
+            return $firstInstalled;
         }
 
         return [
@@ -117,8 +141,8 @@ class SystemStatusService
      */
     private function diskUsage(string $path): array
     {
-        $total = @disk_total_space($path) ?: 0;
-        $free = @disk_free_space($path) ?: 0;
+        $total = (function_exists('disk_total_space') && is_readable($path)) ? (disk_total_space($path) ?: 0) : 0;
+        $free = (function_exists('disk_free_space') && is_readable($path)) ? (disk_free_space($path) ?: 0) : 0;
         $used = max(0, $total - $free);
         $percent = $total > 0 ? round(($used / $total) * 100, 1) : null;
 
@@ -139,7 +163,9 @@ class SystemStatusService
      */
     private function memoryUsage(): array
     {
-        $memInfo = @file('/proc/meminfo', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+        $memInfo = is_readable('/proc/meminfo')
+            ? (file('/proc/meminfo', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [])
+            : [];
         $values = [];
 
         foreach ($memInfo as $line) {
@@ -181,7 +207,9 @@ class SystemStatusService
 
     private function cpuCores(): int
     {
-        $cpuInfo = @file('/proc/cpuinfo', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+        $cpuInfo = is_readable('/proc/cpuinfo')
+            ? (file('/proc/cpuinfo', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [])
+            : [];
         $cores = count(array_filter($cpuInfo, static fn (string $line): bool => str_starts_with($line, 'processor')));
 
         return max(1, $cores);
@@ -189,13 +217,22 @@ class SystemStatusService
 
     private function commandExists(string $command): bool
     {
-        $result = trim($this->runCommand(sprintf('command -v %s 2>/dev/null', escapeshellarg($command))));
+        $result = trim($this->runCommand(sprintf('command -v %s', escapeshellarg($command))));
         return $result !== '';
     }
 
     private function runCommand(string $command): string
     {
-        return (string) shell_exec($command);
+        try {
+            $result = $this->shell->execute('bash', ['-lc', $command . ' 2>/dev/null']);
+            if (($result['exitCode'] ?? 1) !== 0) {
+                return '';
+            }
+
+            return (string) ($result['output'] ?? '');
+        } catch (\Throwable) {
+            return '';
+        }
     }
 
     private function formatBytes(int|float $bytes): string

--- a/app/Support/SystemStatusService.php
+++ b/app/Support/SystemStatusService.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Support;
+
+class SystemStatusService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function snapshot(): array
+    {
+        $services = [
+            $this->inspectService('nginx', 'Nginx', ['nginx']),
+            $this->inspectService('php_fpm', 'PHP-FPM', $this->phpFpmUnits()),
+            $this->inspectService('mysql', 'MySQL', ['mysql', 'mariadb']),
+            $this->inspectService('bind', 'BIND', ['bind9', 'named']),
+            $this->inspectService('ftp', 'FTP', ['pure-ftpd', 'vsftpd', 'proftpd']),
+        ];
+
+        $healthyServices = count(array_filter($services, static fn (array $service): bool => $service['healthy']));
+        $installedServices = count(array_filter($services, static fn (array $service): bool => $service['installed']));
+
+        return [
+            'services' => $services,
+            'disk' => $this->diskUsage('/'),
+            'memory' => $this->memoryUsage(),
+            'load' => $this->loadAverage(),
+            'health' => [
+                'healthy' => $healthyServices,
+                'installed' => $installedServices,
+                'total' => count($services),
+                'summary' => $installedServices === 0
+                    ? 'Service discovery unavailable'
+                    : sprintf('%d of %d installed services healthy', $healthyServices, $installedServices),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, string> $units
+     * @return array<string, mixed>
+     */
+    private function inspectService(string $key, string $label, array $units): array
+    {
+        if (!$this->commandExists('systemctl')) {
+            return [
+                'key' => $key,
+                'label' => $label,
+                'unit' => null,
+                'installed' => false,
+                'healthy' => false,
+                'state' => 'unknown',
+                'badge' => 'secondary',
+                'details' => 'systemctl is not available on this host.',
+            ];
+        }
+
+        foreach ($units as $unit) {
+            $loadState = trim($this->runCommand(sprintf('systemctl show %s --property=LoadState --value 2>/dev/null', escapeshellarg($unit))));
+
+            if ($loadState === '' || $loadState === 'not-found') {
+                continue;
+            }
+
+            $activeState = trim($this->runCommand(sprintf('systemctl show %s --property=ActiveState --value 2>/dev/null', escapeshellarg($unit))));
+            $subState = trim($this->runCommand(sprintf('systemctl show %s --property=SubState --value 2>/dev/null', escapeshellarg($unit))));
+
+            $healthy = $activeState === 'active';
+
+            return [
+                'key' => $key,
+                'label' => $label,
+                'unit' => $unit,
+                'installed' => true,
+                'healthy' => $healthy,
+                'state' => $activeState !== '' ? $activeState : 'unknown',
+                'badge' => $healthy ? 'success' : 'warning',
+                'details' => $subState !== ''
+                    ? sprintf('Unit %s is %s (%s).', $unit, $activeState ?: 'unknown', $subState)
+                    : sprintf('Unit %s is %s.', $unit, $activeState ?: 'unknown'),
+            ];
+        }
+
+        return [
+            'key' => $key,
+            'label' => $label,
+            'unit' => null,
+            'installed' => false,
+            'healthy' => false,
+            'state' => 'not installed',
+            'badge' => 'secondary',
+            'details' => sprintf('No matching service unit found for %s.', $label),
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function phpFpmUnits(): array
+    {
+        $units = [];
+
+        foreach (glob('/etc/php/*/fpm') ?: [] as $path) {
+            $version = basename(dirname($path));
+            $units[] = sprintf('php%s-fpm', $version);
+        }
+
+        if ($units === []) {
+            $units = ['php8.3-fpm', 'php8.2-fpm', 'php8.1-fpm', 'php8.0-fpm', 'php7.4-fpm'];
+        }
+
+        return array_values(array_unique($units));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function diskUsage(string $path): array
+    {
+        $total = @disk_total_space($path) ?: 0;
+        $free = @disk_free_space($path) ?: 0;
+        $used = max(0, $total - $free);
+        $percent = $total > 0 ? round(($used / $total) * 100, 1) : null;
+
+        return [
+            'path' => $path,
+            'used' => $used,
+            'free' => $free,
+            'total' => $total,
+            'used_human' => $this->formatBytes($used),
+            'free_human' => $this->formatBytes($free),
+            'total_human' => $this->formatBytes($total),
+            'percent' => $percent,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function memoryUsage(): array
+    {
+        $memInfo = @file('/proc/meminfo', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+        $values = [];
+
+        foreach ($memInfo as $line) {
+            if (preg_match('/^(\w+):\s+(\d+)/', $line, $matches)) {
+                $values[$matches[1]] = (int) $matches[2] * 1024;
+            }
+        }
+
+        $total = $values['MemTotal'] ?? 0;
+        $available = $values['MemAvailable'] ?? ($values['MemFree'] ?? 0);
+        $used = max(0, $total - $available);
+        $percent = $total > 0 ? round(($used / $total) * 100, 1) : null;
+
+        return [
+            'used' => $used,
+            'available' => $available,
+            'total' => $total,
+            'used_human' => $this->formatBytes($used),
+            'available_human' => $this->formatBytes($available),
+            'total_human' => $this->formatBytes($total),
+            'percent' => $percent,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadAverage(): array
+    {
+        $load = sys_getloadavg();
+
+        return [
+            'one' => $load[0] ?? 0.0,
+            'five' => $load[1] ?? 0.0,
+            'fifteen' => $load[2] ?? 0.0,
+            'cpu_cores' => $this->cpuCores(),
+        ];
+    }
+
+    private function cpuCores(): int
+    {
+        $cpuInfo = @file('/proc/cpuinfo', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+        $cores = count(array_filter($cpuInfo, static fn (string $line): bool => str_starts_with($line, 'processor')));
+
+        return max(1, $cores);
+    }
+
+    private function commandExists(string $command): bool
+    {
+        $result = trim($this->runCommand(sprintf('command -v %s 2>/dev/null', escapeshellarg($command))));
+        return $result !== '';
+    }
+
+    private function runCommand(string $command): string
+    {
+        return (string) shell_exec($command);
+    }
+
+    private function formatBytes(int|float $bytes): string
+    {
+        if ($bytes <= 0) {
+            return '0 B';
+        }
+
+        $units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        $power = (int) floor(log($bytes, 1024));
+        $power = min($power, count($units) - 1);
+        $value = $bytes / (1024 ** $power);
+
+        return sprintf('%.1f %s', $value, $units[$power]);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -20,6 +20,9 @@ use App\Http\Controllers\DatabaseController;
 use App\Http\Controllers\FtpController;
 use App\Http\Controllers\CronController;
 use App\Http\Controllers\DnsController;
+use App\Http\Controllers\LogsController;
+use App\Http\Controllers\SecurityController;
+use App\Http\Controllers\TemplatesController;
 use App\Http\Middleware\AuthMiddleware;
 
 $router = new Router();
@@ -34,6 +37,7 @@ $router->post('/logout', AuthController::class . '@logout');
 $router->get('/', DashboardController::class . '@index', [AuthMiddleware::class]);
 $router->get('/dashboard', DashboardController::class . '@index', [AuthMiddleware::class]);
 $router->get('/dashboard/stats', DashboardController::class . '@stats', [AuthMiddleware::class]);
+$router->get('/dashboard/system-status', DashboardController::class . '@systemStatus', [AuthMiddleware::class]);
 
 // User routes
 $router->get('/users', UserController::class . '@index', [AuthMiddleware::class]);
@@ -75,6 +79,12 @@ $router->get('/dns/{id}', DnsController::class . '@show', [AuthMiddleware::class
 $router->post('/dns/{id}/records', DnsController::class . '@addRecord', [AuthMiddleware::class]);
 $router->post('/dns/{domainId}/records/{recordId}/delete', DnsController::class . '@deleteRecord', [AuthMiddleware::class]);
 
+
+// Observability and delivery routes
+$router->get('/logs', LogsController::class . '@index', [AuthMiddleware::class]);
+$router->get('/security', SecurityController::class . '@index', [AuthMiddleware::class]);
+$router->post('/security/actions', SecurityController::class . '@runAction', [AuthMiddleware::class]);
+$router->get('/templates', TemplatesController::class . '@index', [AuthMiddleware::class]);
 
 // Terminal routes
 $router->get('/terminal', TerminalController::class . '@index', [AuthMiddleware::class]);

--- a/resources/views/pages/dashboard.php
+++ b/resources/views/pages/dashboard.php
@@ -74,7 +74,7 @@
                     <div class="text-primary mb-2"><i class="bi bi-cpu fs-3"></i></div>
                     <h5>System status</h5>
                     <p class="text-muted">Surface expected panel health signals without leaving the dashboard.</p>
-                    <a href="/dashboard" class="btn btn-sm btn-outline-primary">View module</a>
+                    <a href="/dashboard/system-status" class="btn btn-sm btn-outline-primary">Refresh widget</a>
                 </div>
             </div>
         </div>

--- a/resources/views/pages/dashboard.php
+++ b/resources/views/pages/dashboard.php
@@ -2,23 +2,28 @@
 
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
     <h1 class="h2">Dashboard</h1>
-    <button class="btn btn-sm btn-outline-secondary" 
-            hx-get="/dashboard/stats" 
-            hx-target="#stats-container"
-            hx-swap="innerHTML">
-        <i class="bi bi-arrow-clockwise"></i> Refresh Stats
-    </button>
+    <div class="d-flex gap-2">
+        <button class="btn btn-sm btn-outline-secondary"
+                hx-get="/dashboard/stats"
+                hx-target="#stats-container"
+                hx-swap="innerHTML">
+            <i class="bi bi-arrow-clockwise"></i> Refresh Stats
+        </button>
+        <button class="btn btn-sm btn-outline-primary"
+                hx-get="/dashboard/system-status"
+                hx-target="#system-status-container"
+                hx-swap="innerHTML">
+            <i class="bi bi-cpu"></i> Refresh Status
+        </button>
+    </div>
 </div>
 
 <div class="row" id="stats-container" hx-get="/dashboard/stats" hx-trigger="load, every 30s" hx-swap="innerHTML">
-    <!-- Loading skeleton -->
     <div class="col-md-3 mb-3">
         <div class="card text-white bg-secondary">
             <div class="card-body">
                 <h5 class="card-title">Accounts</h5>
-                <p class="card-text display-4">
-                    <span class="spinner-border spinner-border-sm" role="status"></span>
-                </p>
+                <p class="card-text display-4"><span class="spinner-border spinner-border-sm" role="status"></span></p>
             </div>
         </div>
     </div>
@@ -26,9 +31,7 @@
         <div class="card text-white bg-secondary">
             <div class="card-body">
                 <h5 class="card-title">Sites</h5>
-                <p class="card-text display-4">
-                    <span class="spinner-border spinner-border-sm" role="status"></span>
-                </p>
+                <p class="card-text display-4"><span class="spinner-border spinner-border-sm" role="status"></span></p>
             </div>
         </div>
     </div>
@@ -36,9 +39,7 @@
         <div class="card text-white bg-secondary">
             <div class="card-body">
                 <h5 class="card-title">Databases</h5>
-                <p class="card-text display-4">
-                    <span class="spinner-border spinner-border-sm" role="status"></span>
-                </p>
+                <p class="card-text display-4"><span class="spinner-border spinner-border-sm" role="status"></span></p>
             </div>
         </div>
     </div>
@@ -46,13 +47,69 @@
         <div class="card text-white bg-secondary">
             <div class="card-body">
                 <h5 class="card-title">FTP Users</h5>
-                <p class="card-text display-4">
-                    <span class="spinner-border spinner-border-sm" role="status"></span>
-                </p>
+                <p class="card-text display-4"><span class="spinner-border spinner-border-sm" role="status"></span></p>
             </div>
         </div>
     </div>
 </div>
+
+<section class="mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <div>
+            <h3 class="mb-1">System status</h3>
+            <p class="text-muted mb-0">Track service health, disk pressure, memory usage, and host load from the dashboard.</p>
+        </div>
+    </div>
+    <div id="system-status-container" hx-get="/dashboard/system-status" hx-trigger="load, every 30s" hx-swap="innerHTML">
+        <?php include __DIR__ . '/../partials/widgets/system-status.php'; ?>
+    </div>
+</section>
+
+<section class="mt-4">
+    <h3>Feature wave modules</h3>
+    <div class="row g-3">
+        <div class="col-md-6 col-xl-3">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                    <div class="text-primary mb-2"><i class="bi bi-cpu fs-3"></i></div>
+                    <h5>System status</h5>
+                    <p class="text-muted">Surface expected panel health signals without leaving the dashboard.</p>
+                    <a href="/dashboard" class="btn btn-sm btn-outline-primary">View module</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6 col-xl-3">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                    <div class="text-primary mb-2"><i class="bi bi-journal-text fs-3"></i></div>
+                    <h5>Log viewer</h5>
+                    <p class="text-muted">Review Nginx, PHP-FPM, audit, and application activity from one place.</p>
+                    <a href="/logs" class="btn btn-sm btn-outline-primary">Open logs</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6 col-xl-3">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                    <div class="text-primary mb-2"><i class="bi bi-shield-check fs-3"></i></div>
+                    <h5>Security</h5>
+                    <p class="text-muted">Start with read-only firewall visibility, then run safe actions when supported.</p>
+                    <a href="/security" class="btn btn-sm btn-outline-primary">Review security</a>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6 col-xl-3">
+            <div class="card h-100 border-0 shadow-sm">
+                <div class="card-body">
+                    <div class="text-primary mb-2"><i class="bi bi-grid-1x2 fs-3"></i></div>
+                    <h5>Templates</h5>
+                    <p class="text-muted">Ship starter application blueprints independently from deeper site workflow work.</p>
+                    <a href="/templates" class="btn btn-sm btn-outline-primary">Browse templates</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
 
 <div class="row mt-4">
     <div class="col-md-12">

--- a/resources/views/pages/logs/index.php
+++ b/resources/views/pages/logs/index.php
@@ -67,7 +67,11 @@
                         <?php endif; ?>
                     </div>
                 </div>
-                <pre class="bg-dark text-light p-3 rounded" style="min-height: 540px; max-height: 70vh; overflow: auto;"><?= htmlspecialchars($log['content']) ?></pre>
+                <?php if (!empty($log['available'])): ?>
+                    <pre class="bg-dark text-light p-3 rounded" style="min-height: 540px; max-height: 70vh; overflow: auto;"><?= htmlspecialchars($log['content']) ?></pre>
+                <?php else: ?>
+                    <div class="alert alert-warning mb-0"><?= htmlspecialchars($log['content']) ?></div>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/resources/views/pages/logs/index.php
+++ b/resources/views/pages/logs/index.php
@@ -1,0 +1,77 @@
+<?php ob_start(); ?>
+
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
+    <div>
+        <h1 class="h2 mb-1">Log Viewer</h1>
+        <p class="text-muted mb-0">Review service and panel logs without dropping into the terminal.</p>
+    </div>
+</div>
+
+<form method="GET" action="/logs" class="card border-0 shadow-sm mb-4">
+    <div class="card-body row g-3 align-items-end">
+        <div class="col-md-6">
+            <label for="source" class="form-label">Log source</label>
+            <select class="form-select" id="source" name="source">
+                <?php foreach ($sources as $source): ?>
+                    <option value="<?= htmlspecialchars($source['key']) ?>" <?= $selected === $source['key'] ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($source['label']) ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col-md-3">
+            <label for="lines" class="form-label">Tail lines</label>
+            <select class="form-select" id="lines" name="lines">
+                <?php foreach ([100, 200, 300, 500] as $option): ?>
+                    <option value="<?= $option ?>" <?= (int) $lines === $option ? 'selected' : '' ?>>Last <?= $option ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col-md-3">
+            <button type="submit" class="btn btn-primary w-100">
+                <i class="bi bi-search"></i> Load log
+            </button>
+        </div>
+    </div>
+</form>
+
+<div class="row g-4">
+    <div class="col-lg-4">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body">
+                <h5 class="card-title">Available sources</h5>
+                <div class="list-group list-group-flush">
+                    <?php foreach ($sources as $source): ?>
+                        <div class="list-group-item px-0">
+                            <div class="fw-semibold"><?= htmlspecialchars($source['label']) ?></div>
+                            <div class="small text-muted mb-1"><?= htmlspecialchars($source['description']) ?></div>
+                            <code class="small"><?= htmlspecialchars((string) ($source['path'] ?? 'Unavailable')) ?></code>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-8">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body">
+                <div class="d-flex justify-content-between flex-wrap gap-2 align-items-start mb-3">
+                    <div>
+                        <h5 class="card-title mb-1"><?= htmlspecialchars($log['source']['label']) ?></h5>
+                        <div class="small text-muted"><?= htmlspecialchars($log['source']['description']) ?></div>
+                    </div>
+                    <div class="text-end small text-muted">
+                        <div><?= htmlspecialchars((string) ($log['source']['path'] ?? 'Unavailable')) ?></div>
+                        <?php if (isset($log['updated_at'])): ?>
+                            <div>Updated <?= htmlspecialchars($log['updated_at']) ?> · <?= htmlspecialchars($log['size_human']) ?></div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <pre class="bg-dark text-light p-3 rounded" style="min-height: 540px; max-height: 70vh; overflow: auto;"><?= htmlspecialchars($log['content']) ?></pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php $content = ob_get_clean(); ?>
+<?php include __DIR__ . '/../../layouts/app.php'; ?>

--- a/resources/views/pages/security/index.php
+++ b/resources/views/pages/security/index.php
@@ -41,6 +41,7 @@
                         <?php else: ?>
                             <?php foreach ($component['actions'] as $action): ?>
                                 <form method="POST" action="/security/actions" class="d-inline">
+                                    <input type="hidden" name="_csrf_token" value="<?= htmlspecialchars((string) ($csrfToken ?? '')) ?>">
                                     <input type="hidden" name="action" value="<?= htmlspecialchars($action['key']) ?>">
                                     <button type="submit" class="btn btn-sm btn-outline-primary" <?= $overview['can_manage'] ? '' : 'disabled' ?>>
                                         <?= htmlspecialchars($action['label']) ?>

--- a/resources/views/pages/security/index.php
+++ b/resources/views/pages/security/index.php
@@ -1,0 +1,59 @@
+<?php ob_start(); ?>
+
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
+    <div>
+        <h1 class="h2 mb-1">Security</h1>
+        <p class="text-muted mb-0">Read-only status first, with narrow operational controls when the host supports them.</p>
+    </div>
+</div>
+
+<?php if (!empty($message)): ?>
+    <div class="alert alert-success"><i class="bi bi-check-circle"></i> <?= htmlspecialchars($message) ?></div>
+<?php endif; ?>
+
+<?php if (!empty($error)): ?>
+    <div class="alert alert-danger"><i class="bi bi-exclamation-triangle"></i> <?= htmlspecialchars($error) ?></div>
+<?php endif; ?>
+
+<div class="alert alert-info border-0 shadow-sm">
+    <i class="bi bi-info-circle"></i>
+    Controlled actions are only enabled when NovaPanel can run passwordless sudo on the host.
+</div>
+
+<div class="row g-4">
+    <?php foreach ($overview['components'] as $component): ?>
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex flex-column">
+                    <div class="d-flex justify-content-between align-items-start mb-3">
+                        <div>
+                            <h5 class="card-title mb-1"><?= htmlspecialchars($component['label']) ?></h5>
+                            <p class="text-muted small mb-0">
+                                <?= $component['installed'] ? 'Installed on this host.' : 'Not installed on this host.' ?>
+                            </p>
+                        </div>
+                        <span class="badge bg-<?= htmlspecialchars($component['status']['badge']) ?> text-uppercase"><?= htmlspecialchars($component['status']['state']) ?></span>
+                    </div>
+                    <pre class="bg-light border rounded p-3 flex-grow-1 small"><?= htmlspecialchars($component['status']['details']) ?></pre>
+                    <div class="mt-3 d-flex flex-wrap gap-2">
+                        <?php if ($component['actions'] === []): ?>
+                            <span class="text-muted small">No controlled actions for this component yet.</span>
+                        <?php else: ?>
+                            <?php foreach ($component['actions'] as $action): ?>
+                                <form method="POST" action="/security/actions" class="d-inline">
+                                    <input type="hidden" name="action" value="<?= htmlspecialchars($action['key']) ?>">
+                                    <button type="submit" class="btn btn-sm btn-outline-primary" <?= $overview['can_manage'] ? '' : 'disabled' ?>>
+                                        <?= htmlspecialchars($action['label']) ?>
+                                    </button>
+                                </form>
+                            <?php endforeach; ?>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>
+
+<?php $content = ob_get_clean(); ?>
+<?php include __DIR__ . '/../../layouts/app.php'; ?>

--- a/resources/views/pages/sites/create.php
+++ b/resources/views/pages/sites/create.php
@@ -4,11 +4,11 @@
     <h1 class="h2">Create Site</h1>
 </div>
 
-<div class="row">
+<div class="row g-4">
     <div class="col-md-8">
         <div id="form-messages"></div>
-        <form method="POST" action="/sites" 
-              hx-post="/sites" 
+        <form method="POST" action="/sites"
+              hx-post="/sites"
               hx-target="#form-messages"
               hx-swap="innerHTML"
               hx-indicator="#submit-indicator">
@@ -27,6 +27,18 @@
                     <?php endforeach; ?>
                 </select>
                 <div class="form-text">The panel user who will own and manage this site</div>
+            </div>
+
+            <div class="mb-3">
+                <label for="template" class="form-label">Application Template</label>
+                <select class="form-select" id="template" name="template">
+                    <?php foreach ($templates ?? [] as $template): ?>
+                        <option value="<?= htmlspecialchars($template['key']) ?>" <?= ($selectedTemplate ?? 'basic_php') === $template['key'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($template['name']) ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+                <div class="form-text">Choose a starter blueprint to reduce post-provisioning setup work.</div>
             </div>
 
             <div class="mb-3">
@@ -53,12 +65,27 @@
             </div>
         </form>
     </div>
+    <div class="col-md-4">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body">
+                <h5 class="card-title">Template guide</h5>
+                <div class="list-group list-group-flush">
+                    <?php foreach ($templates ?? [] as $template): ?>
+                        <div class="list-group-item px-0">
+                            <div class="fw-semibold"><?= htmlspecialchars($template['name']) ?></div>
+                            <div class="small text-muted"><?= htmlspecialchars($template['summary']) ?></div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <a href="/templates" class="btn btn-sm btn-outline-primary mt-3">Browse module details</a>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script>
 document.body.addEventListener('htmx:afterRequest', function(evt) {
     if (evt.detail.successful && evt.detail.target.id === 'form-messages') {
-        // Redirect to sites page on success
         setTimeout(() => {
             window.location.href = '/sites';
         }, 1000);

--- a/resources/views/pages/templates/index.php
+++ b/resources/views/pages/templates/index.php
@@ -1,0 +1,30 @@
+<?php ob_start(); ?>
+
+<div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">
+    <div>
+        <h1 class="h2 mb-1">Application Templates</h1>
+        <p class="text-muted mb-0">Ship starter blueprints independently so site onboarding improves incrementally.</p>
+    </div>
+    <a href="/sites/create" class="btn btn-primary"><i class="bi bi-plus-circle"></i> Create site</a>
+</div>
+
+<div class="row g-4">
+    <?php foreach ($templates as $template): ?>
+        <div class="col-md-6 col-xl-4">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body d-flex flex-column">
+                    <span class="badge bg-light text-dark align-self-start mb-3"><?= htmlspecialchars($template['stack']) ?></span>
+                    <h5 class="card-title"><?= htmlspecialchars($template['name']) ?></h5>
+                    <p class="text-muted flex-grow-1"><?= htmlspecialchars($template['summary']) ?></p>
+                    <div class="d-flex justify-content-between align-items-center mt-3">
+                        <code><?= htmlspecialchars($template['key']) ?></code>
+                        <a href="/sites/create?template=<?= urlencode($template['key']) ?>" class="btn btn-sm btn-outline-primary">Use template</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>
+
+<?php $content = ob_get_clean(); ?>
+<?php include __DIR__ . '/../../layouts/app.php'; ?>

--- a/resources/views/partials/sidebar.php
+++ b/resources/views/partials/sidebar.php
@@ -42,6 +42,21 @@
                 </a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/logs">
+                    <i class="bi bi-journal-text"></i> Log Viewer
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/security">
+                    <i class="bi bi-shield-check"></i> Security
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="/templates">
+                    <i class="bi bi-grid-1x2"></i> App Templates
+                </a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/terminal">
                     <i class="bi bi-terminal"></i> Terminal
                 </a>

--- a/resources/views/partials/widgets/system-status.php
+++ b/resources/views/partials/widgets/system-status.php
@@ -1,0 +1,72 @@
+<?php
+$systemStatus = $systemStatus ?? [];
+$health = $systemStatus['health'] ?? ['healthy' => 0, 'installed' => 0, 'total' => 0, 'summary' => 'Unavailable'];
+$disk = $systemStatus['disk'] ?? [];
+$memory = $systemStatus['memory'] ?? [];
+$load = $systemStatus['load'] ?? [];
+$services = $systemStatus['services'] ?? [];
+?>
+<div class="row g-3">
+    <div class="col-lg-4">
+        <div class="card h-100 border-0 shadow-sm">
+            <div class="card-body">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h5 class="card-title mb-0">Service health</h5>
+                    <span class="badge bg-primary"><?= htmlspecialchars((string) $health['healthy']) ?>/<?= htmlspecialchars((string) $health['installed']) ?></span>
+                </div>
+                <p class="text-muted small mb-3"><?= htmlspecialchars((string) $health['summary']) ?></p>
+                <ul class="list-group list-group-flush">
+                    <?php foreach ($services as $service): ?>
+                        <li class="list-group-item d-flex justify-content-between align-items-start px-0">
+                            <div>
+                                <div class="fw-semibold"><?= htmlspecialchars($service['label']) ?></div>
+                                <div class="small text-muted"><?= htmlspecialchars($service['details']) ?></div>
+                            </div>
+                            <span class="badge bg-<?= htmlspecialchars($service['badge']) ?> text-uppercase"><?= htmlspecialchars($service['state']) ?></span>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="card h-100 border-0 shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title">Disk usage</h5>
+                <div class="display-6 mb-1"><?= htmlspecialchars((string) ($disk['percent'] ?? '0')) ?>%</div>
+                <p class="text-muted"><?= htmlspecialchars((string) ($disk['used_human'] ?? '0 B')) ?> used of <?= htmlspecialchars((string) ($disk['total_human'] ?? '0 B')) ?></p>
+                <div class="progress mb-3" role="progressbar" aria-label="Disk usage" aria-valuenow="<?= htmlspecialchars((string) ($disk['percent'] ?? 0)) ?>" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" style="width: <?= htmlspecialchars((string) ($disk['percent'] ?? 0)) ?>%"></div>
+                </div>
+                <div class="small text-muted">Free space: <?= htmlspecialchars((string) ($disk['free_human'] ?? '0 B')) ?></div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-4">
+        <div class="card h-100 border-0 shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title">Memory & load</h5>
+                <div class="mb-3">
+                    <div class="d-flex justify-content-between">
+                        <span>Memory</span>
+                        <strong><?= htmlspecialchars((string) ($memory['percent'] ?? '0')) ?>%</strong>
+                    </div>
+                    <div class="progress mt-2" role="progressbar" aria-label="Memory usage" aria-valuenow="<?= htmlspecialchars((string) ($memory['percent'] ?? 0)) ?>" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress-bar bg-info" style="width: <?= htmlspecialchars((string) ($memory['percent'] ?? 0)) ?>%"></div>
+                    </div>
+                    <div class="small text-muted mt-2"><?= htmlspecialchars((string) ($memory['used_human'] ?? '0 B')) ?> used of <?= htmlspecialchars((string) ($memory['total_human'] ?? '0 B')) ?></div>
+                </div>
+                <dl class="row mb-0 small">
+                    <dt class="col-4">1 min</dt>
+                    <dd class="col-8"><?= htmlspecialchars(number_format((float) ($load['one'] ?? 0), 2)) ?></dd>
+                    <dt class="col-4">5 min</dt>
+                    <dd class="col-8"><?= htmlspecialchars(number_format((float) ($load['five'] ?? 0), 2)) ?></dd>
+                    <dt class="col-4">15 min</dt>
+                    <dd class="col-8"><?= htmlspecialchars(number_format((float) ($load['fifteen'] ?? 0), 2)) ?></dd>
+                    <dt class="col-4">CPU cores</dt>
+                    <dd class="col-8"><?= htmlspecialchars((string) ($load['cpu_cores'] ?? 1)) ?></dd>
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>

--- a/tests/Unit/Support/LogViewerServiceTest.php
+++ b/tests/Unit/Support/LogViewerServiceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\LogViewerService;
+use PHPUnit\Framework\TestCase;
+
+class LogViewerServiceTest extends TestCase
+{
+    private string $projectRoot;
+
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/novapanel-log-viewer-' . uniqid('', true);
+        mkdir($this->projectRoot . '/storage/logs', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->projectRoot);
+    }
+
+    public function testReadReturnsTailOfPanelAuditLog(): void
+    {
+        $lines = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $lines[] = 'audit line ' . $i;
+        }
+
+        file_put_contents($this->projectRoot . '/storage/logs/audit.log', implode("\n", $lines));
+
+        $service = new LogViewerService($this->projectRoot);
+        $result = $service->read('panel_audit', 3);
+
+        $this->assertTrue($result['available']);
+        $this->assertStringContainsString('audit line 8', $result['content']);
+        $this->assertStringContainsString('audit line 10', $result['content']);
+        $this->assertStringNotContainsString('audit line 1', $result['content']);
+    }
+
+    public function testReadReturnsHelpfulMessageWhenPathMissing(): void
+    {
+        $service = new LogViewerService($this->projectRoot);
+        $result = $service->read('panel_app', 100);
+
+        $this->assertFalse($result['available']);
+        $this->assertStringContainsString('not available', strtolower($result['content']));
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $fullPath = $path . '/' . $item;
+            if (is_dir($fullPath)) {
+                $this->removeDirectory($fullPath);
+            } else {
+                unlink($fullPath);
+            }
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Unit/Support/LogViewerServiceTest.php
+++ b/tests/Unit/Support/LogViewerServiceTest.php
@@ -27,7 +27,7 @@ class LogViewerServiceTest extends TestCase
             $lines[] = 'audit line ' . $i;
         }
 
-        file_put_contents($this->projectRoot . '/storage/logs/audit.log', implode("\n", $lines));
+        file_put_contents($this->projectRoot . '/storage/logs/audit.log', implode("\n", $lines) . "\n");
 
         $service = new LogViewerService($this->projectRoot);
         $result = $service->read('panel_audit', 3);

--- a/tests/Unit/Support/SiteTemplateServiceTest.php
+++ b/tests/Unit/Support/SiteTemplateServiceTest.php
@@ -47,6 +47,20 @@ class SiteTemplateServiceTest extends TestCase
         $this->assertStringContainsString('static.example.com', file_get_contents($this->documentRoot . '/index.html'));
     }
 
+    public function testApplyCreatesWordpressTemplateFiles(): void
+    {
+        $service = new SiteTemplateService();
+        $service->apply('wordpress', $this->documentRoot, [
+            'domain' => 'blog.example.com',
+            'owner' => 'alice',
+        ]);
+
+        $this->assertFileExists($this->documentRoot . '/index.php');
+        $this->assertFileExists($this->documentRoot . '/wp-config-sample.php');
+        $this->assertDirectoryExists($this->documentRoot . '/wp-content/uploads');
+        $this->assertStringContainsString('blog.example.com', file_get_contents($this->documentRoot . '/index.php'));
+    }
+
     public function testFindThrowsForUnknownTemplate(): void
     {
         $service = new SiteTemplateService();

--- a/tests/Unit/Support/SiteTemplateServiceTest.php
+++ b/tests/Unit/Support/SiteTemplateServiceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use App\Support\SiteTemplateService;
+use PHPUnit\Framework\TestCase;
+
+class SiteTemplateServiceTest extends TestCase
+{
+    private string $documentRoot;
+
+    protected function setUp(): void
+    {
+        $this->documentRoot = sys_get_temp_dir() . '/novapanel-template-' . uniqid('', true);
+        mkdir($this->documentRoot, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->documentRoot);
+    }
+
+    public function testApplyCreatesBasicPhpTemplateFiles(): void
+    {
+        $service = new SiteTemplateService();
+        $service->apply('basic_php', $this->documentRoot, [
+            'domain' => 'example.com',
+            'owner' => 'alice',
+        ]);
+
+        $this->assertFileExists($this->documentRoot . '/index.php');
+        $this->assertFileExists($this->documentRoot . '/README.md');
+        $this->assertDirectoryExists($this->documentRoot . '/tmp');
+        $this->assertStringContainsString('example.com', file_get_contents($this->documentRoot . '/index.php'));
+    }
+
+    public function testApplyCreatesStaticSiteAssets(): void
+    {
+        $service = new SiteTemplateService();
+        $service->apply('static_site', $this->documentRoot, [
+            'domain' => 'static.example.com',
+            'owner' => 'alice',
+        ]);
+
+        $this->assertFileExists($this->documentRoot . '/index.html');
+        $this->assertFileExists($this->documentRoot . '/assets/css/site.css');
+        $this->assertStringContainsString('static.example.com', file_get_contents($this->documentRoot . '/index.html'));
+    }
+
+    public function testFindThrowsForUnknownTemplate(): void
+    {
+        $service = new SiteTemplateService();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $service->find('unknown-template');
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $items = scandir($path) ?: [];
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $fullPath = $path . '/' . $item;
+            if (is_dir($fullPath)) {
+                $this->removeDirectory($fullPath);
+            } else {
+                unlink($fullPath);
+            }
+        }
+
+        rmdir($path);
+    }
+}


### PR DESCRIPTION
### Motivation

- Surface standard panel expectations (service health, logs, firewall visibility, and starter app scaffolds) as incremental modules so the panel can ship features without a full rewrite. 
- Provide immediate read-only observability with narrowly-scoped controlled actions when the host supports passwordless sudo, reducing friction for operators. 

### Description

- Added a system status service and UI widget that inspects Nginx, PHP-FPM, MySQL, BIND, FTP, disk usage, memory and load via `App\Support\SystemStatusService` and `resources/views/partials/widgets/system-status.php`, and wired it into the dashboard and `DashboardController::systemStatus` for HTMX refreshes. 
- Implemented a log viewer service and view using `App\Support\LogViewerService`, a `LogsController`, route (`/logs`), and a UI at `resources/views/pages/logs/index.php` that can read Nginx access/error, PHP-FPM, and panel logs. 
- Added a security manager service `App\Support\SecurityManagerService`, a `SecurityController`, routes (`/security`, `/security/actions`), and a view `resources/views/pages/security/index.php` that shows UFW/fail2ban status and exposes safe actions (e.g. reload UFW, restart fail2ban) only when passwordless sudo is available. 
- Introduced application templates via `App\Support\SiteTemplateService` (basic PHP, WordPress-ready, static) and integrated template selection into site creation by updating `CreateSiteService` and `SiteController` and adding a `TemplatesController` + `/templates` view; templates scaffold document roots using `SiteTemplateService::apply`. 
- Small plumbing: added routes and sidebar links, updated `App` facade to provide the `SiteTemplateService` to `CreateSiteService`, and created a `system-status` widget partial for dashboard embedding. 
- Added unit tests for the new support services: `tests/Unit/Support/LogViewerServiceTest.php` and `tests/Unit/Support/SiteTemplateServiceTest.php`.

### Testing

- Ran PHP syntax checks across changed PHP files with `find app public resources tests -name '*.php' -print0 | xargs -0 -n1 php -l` and there were no syntax errors. (OK)
- Performed smoke tests via inline `php -r` commands to validate templates scaffolding and log tailing: `SiteTemplateService::apply('static_site', ...)` returned the expected files and `LogViewerService::read('panel_audit', ...)` returned recent lines. (OK)
- Attempted to run unit test suite with `vendor/bin/phpunit` but the container lacked `vendor/` so PHPUnit could not be executed. (blocked: `vendor` missing)
- Attempted `composer install --no-interaction --prefer-dist` but dependency fetch failed due to network/packagist tunnel error (`CONNECT tunnel failed, response 403`), so automated test execution could not be completed in this environment. (blocked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0008acf6c832a9557c39344afaccc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System status monitoring widget displaying service health, disk usage, memory, and CPU metrics
  * Log Viewer for browsing and filtering system logs with configurable tail sizes
  * Security management dashboard for firewall and fail2ban controls
  * Application Templates catalog with template selection during site creation
  * Dashboard feature wave cards linking to new modules

* **UI/UX Improvements**
  * Dashboard refresh with live-updating status widget and new navigation links
  * Site creation form now includes application template selector

<!-- end of auto-generated comment: release notes by coderabbit.ai -->